### PR TITLE
Fixes problem where some books take multiple days.

### DIFF
--- a/abbyy_to_epub3/create_epub.py
+++ b/abbyy_to_epub3/create_epub.py
@@ -1071,6 +1071,7 @@ class Ebook(ArchiveBookItem):
                 debug=self.debug,
             )
             parser.parse_abbyy()
+            self.logger.debug("Done with parse_abbyy")
 
             # Text direction: convert IA abbreviation to epub abbreviation
             direction = {
@@ -1094,6 +1095,7 @@ class Ebook(ArchiveBookItem):
                 self.version = self.metadata['fr-version']
 
             # make the HTML chapters
+            self.logger.debug("craft_html")
             self.craft_html()
             self.logger.debug("Done assembling the HTML")
 

--- a/abbyy_to_epub3/parse_abbyy.py
+++ b/abbyy_to_epub3/parse_abbyy.py
@@ -37,7 +37,7 @@ def add_last_text(blocks, page):
         elem = blocks[-1]
         if 'page_no' not in elem:
             return
-        # return if we reacherd the previous page without hitting text
+        # return if we reached the previous page without hitting text
         if elem['page_no'] <= page:
             return
         # If page_no is here and is text, set elem to 'last'


### PR DESCRIPTION
A regression was introduced in the memory fixes which made add_last_text iterate through the entire parsed blocks list with every page. Fixed, and added some debugging messages.