### PR TITLE
Handle myriad language code inputs (and errors) gracefully.

### DIFF
--- a/abbyy_to_epub3/parse_abbyy.py
+++ b/abbyy_to_epub3/parse_abbyy.py
@@ -217,14 +217,23 @@ class AbbyyParser(object):
                 self.metadata[term.tag] = [term.text, ]
 
         # if the language isn't explicitly set, assume English
-        # convert to the correct ISO standard
+        # if the language code is invalid, assume English
+        # language might be ISO 639-6, ISO 639-2/B, ISO 639-2/T, or ISO 639-1
+        # (in pycountry, called: name, alpha_3, bibliographic, and alpha_2)
         if 'language' not in self.metadata:
             self.metadata['language'] = ['en']
         else:
             lang_code = self.metadata['language'][0]
-            if len(lang_code) == 3:
-                lang = pycountry.languages.get(alpha_3=lang_code)
+            try:
+                lang = pycountry.languages.lookup(lang_code)
                 self.metadata['language'][0] = lang.alpha_2
+            except LookupError:
+                self.logger.debug(
+                    "Invalid language code {}. Setting to English".format(
+                        lang_code
+                    )
+                )
+                self.metadata['language'][0] = 'en'
 
     def parse_abbyy(self):
         """

--- a/abbyy_to_epub3/tests/test_parse_abbyy.py
+++ b/abbyy_to_epub3/tests/test_parse_abbyy.py
@@ -86,3 +86,47 @@ class TestAbbyyParser(object):
         result = sanitize_xml(text)
 
         assert result == good
+
+    def test_parse_iso639_1(self, finereader10):
+        """ Understands an ISO 639-1 (alpha-2) language entry. """
+        parser = finereader10
+        self.metadata['language'] = ['wo']
+        parser.parse_metadata()
+
+        assert self.metadata['language'][0] == 'wo'
+
+    def test_parse_iso639_2T(self, finereader10):
+        """
+        Understands an ISO 639-2/T (alpha-3 terminological) language entry.
+        """
+        parser = finereader10
+        self.metadata['language'] = ['deu']
+        parser.parse_metadata()
+
+        assert self.metadata['language'][0] == 'de'
+
+    def test_parse_iso639_2B(self, finereader10):
+        """
+        Understands an ISO 639-2/B (alpha-3 bibliographic) language entry.
+        """
+        parser = finereader10
+        self.metadata['language'] = ['ger']
+        parser.parse_metadata()
+
+        assert self.metadata['language'][0] == 'de'
+
+    def test_parse_iso639_6(self, finereader10):
+        """ Understands an ISO 639-6 (English name) language entry. """
+        parser = finereader10
+        self.metadata['language'] = ['Cree']
+        parser.parse_metadata()
+
+        assert self.metadata['language'][0] == 'cr'
+
+    def test_parse_bad_lang(self, finereader10):
+        """ If language entry is bogus, set to English. """
+        parser = finereader10
+        self.metadata['language'] = ['Rikchik']
+        parser.parse_metadata()
+
+        assert self.metadata['language'][0] == 'en'


### PR DESCRIPTION
Fixes #25 The `<language>` element in metadata isn't standardized; it looks like all of the ISO 639 substandards are used in IA inputs. Handle the language without knowing what standard is used, and gracefully fall back to English on garbage input.