### PR TITLE
Fixes #28 EOL whitespace problems

### DIFF
--- a/abbyy_to_epub3/utils.py
+++ b/abbyy_to_epub3/utils.py
@@ -53,7 +53,10 @@ def sanitize_xml(text):
 
 
 def gettext(elem):
-    """ Given an element, get all text from within element and its children """
+    """
+    Given an element, get all text from within element and its children.
+    Strips out file artifact whitespace (unlike etree.itertext).
+    """
     text = elem.text or ""
     for e in elem:
         text += gettext(e)
@@ -62,7 +65,6 @@ def gettext(elem):
     return text
 
 
-#@profile
 def fast_iter(context, func):
     """
     Garbage collect as you iterate to save memory


### PR DESCRIPTION
1. Ignores whitespace between elements in ABBYY, and therefore adds whitespace at end of <line> elements.
1. Strips out a larger set of EOL hyphens.

Hyphenation fix has some false positives, eg:

>   She was an all-
>   American athlete.
> 

but the net benefit is positive.