### PR TITLE
Issue #39 crash when pagenos on an empty page

### DIFF
--- a/abbyy_to_epub3/parse_abbyy.py
+++ b/abbyy_to_epub3/parse_abbyy.py
@@ -355,6 +355,7 @@ class AbbyyParser(object):
             # with content.
             if (
                 self.metadata['PAGES_SUPPORT'] and
+                len(self.blocks) > 1 and
                 self.blocks[-1]['type'] != 'Page'
             ):
                 self.blocks.append({

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fuzzywuzzy[speedup]==0.17.0
 lxml==4.4.1
 mock==3.0.5
 numeral==0.1.0.11
-pillow==6.1.0
+pillow>=6.2.1
 pycountry==19.8.18
 PyExecJs==1.5.1
 pytest==5.2.0


### PR DESCRIPTION
1. Under certain circumstances, a page with no content blocks can ask for a page number. Handle this correctly.
2. Updated pillow for security vulnerability.

@mekarpeles 
@bfalling 