### PR TITLE
Adds check, prevents missing page blocks from crash

### DIFF
--- a/abbyy_to_epub3/__init__.py
+++ b/abbyy_to_epub3/__init__.py
@@ -1,4 +1,4 @@
 
 __title__ = 'abbyy_to_epub3'
-__version__ = '1.7.4'
+__version__ = '1.7.6'
 __author__ = '@deborahgu'

--- a/abbyy_to_epub3/parse_abbyy.py
+++ b/abbyy_to_epub3/parse_abbyy.py
@@ -355,6 +355,7 @@ class AbbyyParser(object):
             # with content.
             if (
                 self.metadata['PAGES_SUPPORT'] and
+                self.blocks and
                 self.blocks[-1]['type'] != 'Page'
             ):
                 self.blocks.append({


### PR DESCRIPTION
If a block was empty, this was causing an index error; check added to ensure list is not empty.